### PR TITLE
Allow fxml.hrl to be found from system libs.

### DIFF
--- a/include/xmpp.hrl
+++ b/include/xmpp.hrl
@@ -26,7 +26,7 @@
 -include("ns.hrl").
 -include("jid.hrl").
 -include("xmpp_codec.hrl").
--include("fxml.hrl").
+-include_lib("fast_xml/include/fxml.hrl").
 
 -type stanza() :: iq() | presence() | message().
 


### PR DESCRIPTION
This commit adjusts an include() call to be include_lib() so that
fxml.hrl can be found when it is installed in /usr/lib rather than
in a local deps folder.